### PR TITLE
refactor: calculate state in model response

### DIFF
--- a/src/commands/init/init.ts
+++ b/src/commands/init/init.ts
@@ -1,7 +1,7 @@
 import prompts from 'prompts';
 import { checkIfConfigExists, createConfigFile } from '../../config-file';
 import * as output from '../../output';
-import { getProvider } from '../../providers';
+import { getProvider } from '../../providers/provider';
 
 export async function init() {
   try {

--- a/src/commands/prompt/index.ts
+++ b/src/commands/prompt/index.ts
@@ -3,7 +3,11 @@ import { checkIfConfigExists, parseConfigFile } from '../../config-file';
 import { type Message } from '../../inference';
 import { inputLine } from '../../input';
 import * as output from '../../output';
-import { getDefaultProvider, providerOptions, resolveProviderFromOption } from '../../providers';
+import {
+  getDefaultProvider,
+  providerOptions,
+  resolveProviderFromOption,
+} from '../../providers/provider';
 import { init } from '../init/init';
 import { processCommand } from './commands';
 
@@ -112,16 +116,12 @@ async function runInternal(initialPrompt: string, options: PromptOptions) {
     output.outputAiProgress('Thinking...');
 
     messages.push({ role: 'user', content: initialPrompt });
-
-    const startTimestamp = performance.now();
-    const [content, response] = await provider.getChatCompletion(config, messages);
-    const responseTime = performance.now() - startTimestamp;
-    const stats = { ...response?.usage, responseTime };
+    const { messageText, stats, response } = await provider.getChatCompletion(config, messages);
 
     output.clearLine();
     output.outputVerbose(`Response: ${JSON.stringify(response, null, 2)}`);
-    output.outputAi(content ?? '(null)', stats);
-    messages.push({ role: 'assistant', content: content ?? '' });
+    output.outputAi(messageText ?? '(null)', stats);
+    messages.push({ role: 'assistant', content: messageText ?? '' });
   } else {
     output.outputAi('Hello, how can I help you?');
   }
@@ -145,16 +145,12 @@ async function runInternal(initialPrompt: string, options: PromptOptions) {
     output.outputAiProgress('Thinking...');
 
     messages.push({ role: 'user', content: userPrompt });
-
-    const startTimestamp = performance.now();
-    const [content, response] = await provider.getChatCompletion(config, messages);
-    const responseTime = performance.now() - startTimestamp;
-    const stats = { ...response?.usage, responseTime };
+    const { messageText, stats, response } = await provider.getChatCompletion(config, messages);
 
     output.clearLine();
     output.outputVerbose(`Response Object: ${JSON.stringify(response, null, 2)}`);
-    output.outputAi(content ?? '(null)', stats);
-    messages.push({ role: 'assistant', content: content ?? '' });
+    output.outputAi(messageText ?? '(null)', stats);
+    messages.push({ role: 'assistant', content: messageText ?? '' });
   }
 }
 

--- a/src/inference.ts
+++ b/src/inference.ts
@@ -15,13 +15,14 @@ export interface AiMessage {
   content: string;
 }
 
-export interface UsageStats {
-  prompt_tokens: number;
-  completion_tokens: number;
+export interface ModelResponse {
+  messageText: string | null;
+  stats: ModelResponseStats;
+  response: unknown;
 }
 
-export interface ResponseStats {
+export interface ModelResponseStats {
   responseTime: number;
-  prompt_tokens?: number;
-  completion_tokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,6 +1,6 @@
 import * as readline from 'readline';
 import chalk from 'chalk';
-import type { ResponseStats } from './inference';
+import type { ModelResponseStats } from './inference';
 
 let verbose = false;
 let showStats = false;
@@ -25,7 +25,7 @@ export function outputUser(message: string) {
   console.log('me:', message);
 }
 
-export function outputAi(message: string, stats?: ResponseStats) {
+export function outputAi(message: string, stats?: ModelResponseStats) {
   const statsOutput = stats && showStats ? chalk.dim(formatStats(stats)) : '';
 
   console.log(chalk.cyan('ai:', message), statsOutput);
@@ -82,10 +82,10 @@ function extractErrorMessage(error: unknown) {
   return 'Unknown error';
 }
 
-function formatStats(stats: ResponseStats) {
+function formatStats(stats: ModelResponseStats) {
   const parts = [
     `time: ${(stats.responseTime / 1000).toFixed(1)} s`,
-    `tokens: ${stats.prompt_tokens} in + ${stats.completion_tokens} out`,
+    `tokens: ${stats.inputTokens} in + ${stats.outputTokens} out`,
   ];
 
   return `(${parts.join(', ')})`;

--- a/src/providers/openAi.ts
+++ b/src/providers/openAi.ts
@@ -1,7 +1,7 @@
 import OpenAI from 'openai';
 import { type Message } from '../inference';
 import type { ProviderConfig } from './config';
-import type { Provider } from '.';
+import type { Provider } from './provider';
 
 const OpenAi: Provider = {
   label: 'OpenAI',
@@ -17,12 +17,22 @@ const OpenAi: Provider = {
       content: config.systemPrompt,
     };
 
+    const startTime = performance.now();
     const response = await openai.chat.completions.create({
       messages: [systemMessage, ...messages],
       model: config.model,
     });
+    const responseTime = performance.now() - startTime;
 
-    return [response.choices[0]?.message.content ?? null, response] as const;
+    return {
+      messageText: response.choices[0]?.message.content ?? null,
+      stats: {
+        responseTime,
+        inputTokens: response.usage?.prompt_tokens,
+        outputTokens: response.usage?.completion_tokens,
+      },
+      response,
+    };
   },
 };
 

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -1,14 +1,15 @@
 import OpenAI from 'openai';
 import { type Message } from '../inference';
 import type { ProviderConfig } from './config';
-import type { Provider } from '.';
+import type { Provider } from './provider';
 
 const Perplexity: Provider = {
   label: 'Perplexity',
   name: 'perplexity',
   apiKeyUrl: 'https://perplexity.ai/settings/api',
+
   getChatCompletion: async (config: ProviderConfig, messages: Message[]) => {
-    const perplexity = new OpenAI({
+    const openai = new OpenAI({
       apiKey: config.apiKey,
       baseURL: 'https://api.perplexity.ai',
     });
@@ -18,12 +19,22 @@ const Perplexity: Provider = {
       content: config.systemPrompt,
     };
 
-    const response = await perplexity.chat.completions.create({
+    const startTime = performance.now();
+    const response = await openai.chat.completions.create({
       messages: [systemMessage, ...messages],
       model: config.model,
     });
+    const responseTime = performance.now() - startTime;
 
-    return [response.choices[0]?.message.content ?? null, response] as const;
+    return {
+      messageText: response.choices[0]?.message.content ?? null,
+      stats: {
+        responseTime,
+        inputTokens: response.usage?.prompt_tokens,
+        outputTokens: response.usage?.completion_tokens,
+      },
+      response,
+    };
   },
 };
 

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,5 +1,5 @@
 import type { ConfigFile } from '../config-file';
-import type { Message } from '../inference';
+import type { Message, ModelResponse } from '../inference';
 import type { ProviderConfig } from './config';
 import openAi from './openAi';
 import perplexity from './perplexity';
@@ -11,7 +11,7 @@ export type Provider = {
   name: ProviderName;
   label: string;
   apiKeyUrl: string;
-  getChatCompletion: (config: ProviderConfig, messages: Message[]) => any;
+  getChatCompletion: (config: ProviderConfig, messages: Message[]) => Promise<ModelResponse>;
 };
 
 const providers: Record<ProviderName, Provider> = {


### PR DESCRIPTION
### Summary

* Internalize stats calculation in the provider objects as stats logic is specific to each provider
* Strongly type result of `getChatCompletion` function

### Test plan

Manual tests