### PR TITLE
fix: handle inference error gracefully

### DIFF
--- a/src/commands/chat/state/actions.ts
+++ b/src/commands/chat/state/actions.ts
@@ -38,6 +38,19 @@ export function addProgramMessage(text: string, level: MessageLevel = 'info') {
   });
 }
 
+export function removeUnansweredUserContextMessage() {
+  useChatState.setState((state) => {
+    const lastMessage = state.contextMessages.at(-1);
+    if (lastMessage?.role !== 'user') {
+      return state;
+    }
+
+    return {
+      contextMessages: state.contextMessages.slice(0, state.contextMessages.length - 1),
+    };
+  });
+}
+
 export function forgetContextMessages() {
   useChatState.setState((state) => {
     return {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

OpenAI & Perplexity APIs require user and assistant messages to be alternating for chat completion call. When error happened in calling that APIs, we left unanswered user message. This fix removes such message.

### Test plan

Manual testing.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
