### PR TITLE
refactor: store token price per million

### DIFF
--- a/src/engine/providers/anthropic.ts
+++ b/src/engine/providers/anthropic.ts
@@ -18,7 +18,7 @@ const Anthropic: Provider = {
   // Anthropic models: https://docs.anthropic.com/claude/docs/models-overview
   defaultModel: 'claude-3-sonnet-20240229',
 
-  // Price per 1k tokens [input, output].
+  // Price per 1M tokens [input, output].
   // Source: https://www.anthropic.com/api
   modelPricing: {
     'claude-3-haiku-20240307': { inputTokensCost: 0.25, outputTokensCost: 1.25 },

--- a/src/engine/providers/anthropic.ts
+++ b/src/engine/providers/anthropic.ts
@@ -21,12 +21,12 @@ const Anthropic: Provider = {
   // Price per 1k tokens [input, output].
   // Source: https://www.anthropic.com/api
   modelPricing: {
-    'claude-3-haiku-20240307': { inputTokensCost: 0.25 / 1000, outputTokensCost: 1.25 / 1000 },
-    'claude-3-sonnet-20240229': { inputTokensCost: 3.0 / 1000, outputTokensCost: 15.0 / 1000 },
-    'claude-3-opus-20240229': { inputTokensCost: 15.0 / 1000, outputTokensCost: 75.0 / 1000 },
-    'claude-2.1': { inputTokensCost: 8.0 / 1000, outputTokensCost: 24.0 / 1000 },
-    'claude-2.0': { inputTokensCost: 8.0 / 1000, outputTokensCost: 24.0 / 1000 },
-    'claude-instant-1.2': { inputTokensCost: 0.8 / 1000, outputTokensCost: 2.4 / 1000 },
+    'claude-3-haiku-20240307': { inputTokensCost: 0.25, outputTokensCost: 1.25 },
+    'claude-3-sonnet-20240229': { inputTokensCost: 3.0, outputTokensCost: 15.0 },
+    'claude-3-opus-20240229': { inputTokensCost: 15.0, outputTokensCost: 75.0 },
+    'claude-2.1': { inputTokensCost: 8.0, outputTokensCost: 24.0 },
+    'claude-2.0': { inputTokensCost: 8.0, outputTokensCost: 24.0 },
+    'claude-instant-1.2': { inputTokensCost: 0.8, outputTokensCost: 2.4 },
   },
 
   modelAliases: {

--- a/src/engine/providers/openAi.ts
+++ b/src/engine/providers/openAi.ts
@@ -10,24 +10,22 @@ const OpenAi: Provider = {
   apiKeyUrl: 'https://platform.openai.com/api-keys',
 
   // OpenAI models: https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo
-  defaultModel: 'gpt-4-turbo-preview',
+  defaultModel: 'gpt-4-turbo',
 
-  // Price per 1k tokens [input, output].
+  // Price per 1M tokens [input, output].
   // Source: https://openai.com/pricing
   modelPricing: {
-    'gpt-4-turbo-preview': { inputTokensCost: 0.01, outputTokensCost: 0.03 },
-    'gpt-4-0125-preview': { inputTokensCost: 0.01, outputTokensCost: 0.03 },
-    'gpt-4-1106-preview': { inputTokensCost: 0.01, outputTokensCost: 0.03 },
-    'gpt-4': { inputTokensCost: 0.03, outputTokensCost: 0.06 },
-    'gpt-4-0613': { inputTokensCost: 0.03, outputTokensCost: 0.06 },
-    'gpt-4-32k': { inputTokensCost: 0.06, outputTokensCost: 0.12 },
-    'gpt-4-32k-0613': { inputTokensCost: 0.06, outputTokensCost: 0.12 },
-    'gpt-3.5-turbo': { inputTokensCost: 0.0005, outputTokensCost: 0.0015 },
-    'gpt-3.5-turbo-0125': { inputTokensCost: 0.0005, outputTokensCost: 0.0015 },
+    'gpt-4-turbo': { inputTokensCost: 10, outputTokensCost: 30 },
+    'gpt-4-turbo-2024-04-09': { inputTokensCost: 10, outputTokensCost: 30 },
+    'gpt-4': { inputTokensCost: 30, outputTokensCost: 60 },
+    'gpt-4-32k': { inputTokensCost: 60, outputTokensCost: 120 },
+    'gpt-3.5-turbo': { inputTokensCost: 0.5, outputTokensCost: 1.5 },
+    'gpt-3.5-turbo-0125': { inputTokensCost: 0.5, outputTokensCost: 1.5 },
+    'gpt-3.5-turbo-instruct': { inputTokensCost: 1.5, outputTokensCost: 2.0 },
   },
 
   modelAliases: {
-    'gpt-4-turbo': 'gpt-4-turbo-preview',
+    'gpt-4-turbo-preview': 'gpt-4-turbo',
     'gpt-3.5': 'gpt-3.5-turbo',
   },
 

--- a/src/engine/providers/perplexity.ts
+++ b/src/engine/providers/perplexity.ts
@@ -12,25 +12,25 @@ const Perplexity: Provider = {
   // Perplexity models: https://docs.perplexity.ai/docs/model-cards
   defaultModel: 'sonar-medium-chat',
 
-  // Price per 1k tokens [input, output].
+  // Price per 1M tokens [input, output], per 1k requests.
   // Source: https://docs.perplexity.ai/docs/model-cards
   // Source: https://docs.perplexity.ai/docs/pricing
   modelPricing: {
-    'sonar-small-chat': { inputTokensCost: 0.2 / 1000, outputTokensCost: 0.2 / 1000 },
-    'sonar-medium-chat': { inputTokensCost: 0.6 / 1000, outputTokensCost: 0.6 / 1000 },
+    'sonar-small-chat': { inputTokensCost: 0.2, outputTokensCost: 0.2 },
+    'sonar-medium-chat': { inputTokensCost: 0.6, outputTokensCost: 0.6 },
     'sonar-small-online': {
-      inputTokensCost: 0.2 / 1000,
-      outputTokensCost: 0.2 / 1000,
-      requestsCost: 5 / 1000,
+      inputTokensCost: 0.2,
+      outputTokensCost: 0.2,
+      requestsCost: 5,
     },
     'sonar-medium-online': {
-      inputTokensCost: 0.6 / 1000,
-      outputTokensCost: 0.6 / 1000,
-      requestsCost: 5 / 1000,
+      inputTokensCost: 0.6,
+      outputTokensCost: 0.6,
+      requestsCost: 5,
     },
-    'codellama-70b-instruct': { inputTokensCost: 1 / 1000, outputTokensCost: 1 / 1000 },
-    'mistral-7b-instruct': { inputTokensCost: 0.2 / 1000, outputTokensCost: 0.2 / 1000 },
-    'mixtral-8x7b-instruct': { inputTokensCost: 0.6 / 1000, outputTokensCost: 0.6 / 1000 },
+    'codellama-70b-instruct': { inputTokensCost: 1, outputTokensCost: 1 },
+    'mistral-7b-instruct': { inputTokensCost: 0.2, outputTokensCost: 0.2 },
+    'mixtral-8x7b-instruct': { inputTokensCost: 0.6, outputTokensCost: 0.6 },
   },
 
   modelAliases: {

--- a/src/engine/providers/provider.ts
+++ b/src/engine/providers/provider.ts
@@ -27,13 +27,13 @@ export interface Provider {
 }
 
 export interface ModelPricing {
-  /** Cost per 1k input tokens */
+  /** Cost per 1M input tokens */
   inputTokensCost?: number;
 
-  /** Cost per 1k output tokens */
+  /** Cost per 1M output tokens */
   outputTokensCost?: number;
 
-  /** Cost per 1k requests */
+  /** Cost per 1M requests */
   requestsCost?: number;
 }
 

--- a/src/engine/session.ts
+++ b/src/engine/session.ts
@@ -24,9 +24,9 @@ export function calculateUsageCost(usage: Partial<ModelUsage>, pricing: ModelPri
     return undefined;
   }
 
-  const inputCost = ((usage.inputTokens ?? 0) * (pricing.inputTokensCost ?? 0)) / 1000;
-  const outputCost = ((usage.outputTokens ?? 0) * (pricing.outputTokensCost ?? 0)) / 1000;
-  const requestsCost = ((usage.requests ?? 0) * (pricing.requestsCost ?? 0)) / 1000;
+  const inputCost = ((usage.inputTokens ?? 0) * (pricing.inputTokensCost ?? 0)) / 1_000_000;
+  const outputCost = ((usage.outputTokens ?? 0) * (pricing.outputTokensCost ?? 0)) / 1_000_000;
+  const requestsCost = ((usage.requests ?? 0) * (pricing.requestsCost ?? 0)) / 1_000_000;
   return inputCost + outputCost + requestsCost;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Pricing per million (input, output) tokens seems to become the norm now. Let's store our pricing info in that unit. 

Also:
* update OpenAI to use `gpt-4-turbo`  by default (no longer in preview)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Manual testing for all providers.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
